### PR TITLE
Fixed approvalPrompt, viewPrivate and write in getRequestAccessUrl

### DIFF
--- a/src/org/jstrava/authenticator/AuthResponse.java
+++ b/src/org/jstrava/authenticator/AuthResponse.java
@@ -1,0 +1,14 @@
+package org.jstrava.authenticator;
+
+import org.jstrava.entities.athlete.Athlete;
+
+public class AuthResponse {
+    String access_token;
+    Athlete athlete;
+
+    public String getAccess_token() { return access_token; }
+    public void setAccess_token(String token) { this.access_token = token; }
+
+    public Athlete getAthlete() { return athlete; }
+    public void setAthlete() { this.athlete = athlete; }
+}


### PR DESCRIPTION
According to docs,

> approval_prompt:  string optional 
> ‘force’ or ‘auto’, use ‘force’ to always show the authorization prompt even if the user has already authorized the current application, default is ‘auto’
> scope:    string optional 
> comma delimited string of ‘view_private’ and/or ‘write’, leave blank for read-only permissions.
