### PR TITLE
Fix ProtocolException in StravaAuthenticator

### DIFF
--- a/src/org/jstrava/authenticator/StravaAuthenticator.java
+++ b/src/org/jstrava/authenticator/StravaAuthenticator.java
@@ -103,6 +103,7 @@ public class StravaAuthenticator {
 
                 conn.setRequestMethod("POST");
                 conn.setRequestProperty("Accept", "application/json");
+                conn.setDoOutput(true);
                 OutputStream os = conn.getOutputStream();
                 os.write(sb.toString().getBytes("UTF-8"));
 

--- a/src/org/jstrava/connector/JStravaV3.java
+++ b/src/org/jstrava/connector/JStravaV3.java
@@ -826,7 +826,7 @@ public class JStravaV3 implements JStrava {
 
             if (conn.getResponseCode() != 200) {
                 throw new RuntimeException("Failed : HTTP error code : "
-                        + conn.getResponseCode());
+                        + conn.getResponseCode() + " - " + conn.getResponseMessage());
             }
 
             BufferedReader br = new BufferedReader(new InputStreamReader(
@@ -897,7 +897,7 @@ public class JStravaV3 implements JStrava {
             conn.setRequestProperty("Authorization","Bearer "+getAccessToken());
             if (conn.getResponseCode() != 200) {
                 throw new RuntimeException("Failed : HTTP error code : "
-                        + conn.getResponseCode());
+                        + conn.getResponseCode() + " - " + conn.getResponseMessage());
             }
 
 
@@ -1023,7 +1023,7 @@ public class JStravaV3 implements JStrava {
             conn.setRequestProperty("Authorization","Bearer "+getAccessToken());
             if (conn.getResponseCode() != 200 | conn.getResponseCode() != 201 ) {
                 throw new RuntimeException("Failed : HTTP error code : "
-                        + conn.getResponseCode());
+                        + conn.getResponseCode() + " - " + conn.getResponseMessage());
             }
 
 
@@ -1088,7 +1088,7 @@ public class JStravaV3 implements JStrava {
             conn.setRequestProperty("Authorization","Bearer "+getAccessToken());
             if (conn.getResponseCode() != 200) {
                 throw new RuntimeException("Failed : HTTP error code : "
-                        + conn.getResponseCode());
+                        + conn.getResponseCode() + " - " + conn.getResponseMessage());
             }
 
 
@@ -1135,7 +1135,7 @@ public class JStravaV3 implements JStrava {
             conn.setRequestProperty("Authorization","Bearer "+getAccessToken());
             if (conn.getResponseCode() != 204) {
                 throw new RuntimeException("Failed : HTTP error code : "
-                        + conn.getResponseCode());
+                        + conn.getResponseCode() + " - " + conn.getResponseMessage());
             }
 
 


### PR DESCRIPTION
Two things here:

1. Switch URLConnection to output mode before writing to its output stream.
Without this a ProtocolException is thrown with error message "cannot write to a URLConnection if doOutput=false - call setDoOutput(true)"

2. Minor changes to runtime exception message which is thrown in case of HTTP errors (now it includes response message too, not only the response code).
